### PR TITLE
Add #[\ReturnTypeWillChange] attribute to disable PHP 8.1 deprecation notices

### DIFF
--- a/lib/Core/Pagination/Pagerfanta/Slice.php
+++ b/lib/Core/Pagination/Pagerfanta/Slice.php
@@ -43,21 +43,25 @@ final class Slice implements IteratorAggregate, ArrayAccess
         );
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->searchHits);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->searchHits[$offset]->valueObject;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         throw new RuntimeException('Method ' . __METHOD__ . ' is not supported');
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         throw new RuntimeException('Method ' . __METHOD__ . ' is not supported');


### PR DESCRIPTION
PHP 8.1 emmits the notice like this:

```
Deprecated: Return type of Netgen\IbexaSearchExtra\Core\Pagination\Pagerfanta\Slice::offsetGet($offset)
should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange]
attribute should be used to temporarily suppress the notice
```