### PR TITLE
NGSTACK-788 return 0 when max score is null

### DIFF
--- a/lib/Core/Pagination/Pagerfanta/BaseAdapter.php
+++ b/lib/Core/Pagination/Pagerfanta/BaseAdapter.php
@@ -64,7 +64,7 @@ abstract class BaseAdapter implements AdapterInterface, SearchResultExtras
     {
         $this->initializeExtraInfo();
 
-        return $this->maxScore;
+        return $this->maxScore ?? 0;
     }
 
     public function getSuggestion(): Suggestion


### PR DESCRIPTION
https://netgen.atlassian.net/browse/NGSTACK-788
When maxScore is null, getMaxScore method now returns 0 so we can keep treating is as float type. 