### PR TITLE
Convert UserEnabledFieldMapper to block mapper & make criterion visitor available for both content and location searches

### DIFF
--- a/lib/Core/Search/Solr/Query/Common/CriterionVisitor/UserEnabled.php
+++ b/lib/Core/Search/Solr/Query/Common/CriterionVisitor/UserEnabled.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Netgen\IbexaSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor;
+namespace Netgen\IbexaSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Solr\Query\CriterionVisitor;

--- a/lib/Resources/config/search/solr/criterion_visitors.yaml
+++ b/lib/Resources/config/search/solr/criterion_visitors.yaml
@@ -95,6 +95,7 @@ services:
             - { name: ibexa.search.solr.query.location.criterion.visitor }
 
     netgen.ibexa_search_extra.solr.query.content.criterion_visitor.user_enabled:
-        class: Netgen\IbexaSearchExtra\Core\Search\Solr\Query\Content\CriterionVisitor\UserEnabled
+        class: Netgen\IbexaSearchExtra\Core\Search\Solr\Query\Common\CriterionVisitor\UserEnabled
         tags:
             - { name: ibexa.search.solr.query.content.criterion.visitor }
+            - { name: ibexa.search.solr.query.location.criterion.visitor }

--- a/lib/Resources/config/search/solr/field_mappers.yaml
+++ b/lib/Resources/config/search/solr/field_mappers.yaml
@@ -28,7 +28,7 @@ services:
         tags:
             - { name: ibexa.search.solr.field.mapper.location }
 
-    netgen.ibexa_search_extra.solr.field_mapper.content.user_enabled:
+    netgen.ibexa_search_extra.solr.field_mapper.common.user_enabled:
         class: Netgen\IbexaSearchExtra\Core\Search\Solr\FieldMapper\Content\UserEnabledFieldMapper
         tags:
-            - { name: ibexa.search.solr.field.mapper.content }
+            - { name: ibexa.search.solr.field.mapper.block }


### PR DESCRIPTION
This is a follow up after https://github.com/netgen/ibexa-search-extra/pull/13
We need to add this flag in both content and location documents and make possible to use it in both content and location searches.

It should also be forward merged to the master branch/3.2 after the PR is accepted and merged.