### PR TITLE
NGSTACK-809 index file content

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -31,13 +31,14 @@ class Configuration implements ConfigurationInterface
         $this->addFulltextBoostSection($rootNode);
         $this->addUsePageIndexingSection($rootNode);
         $this->addPageIndexingSection($rootNode);
+        $this->addFileTextExtractionSection($rootNode);
 
         return $treeBuilder;
     }
 
     private function addIndexableFieldTypeSection(ArrayNodeDefinition $nodeDefinition): void
     {
-        /** @noinspection NullPointerExceptionInspection */
+        /* @noinspection NullPointerExceptionInspection */
         $nodeDefinition
             ->children()
                 ->arrayNode('indexable_field_type')
@@ -61,7 +62,7 @@ class Configuration implements ConfigurationInterface
 
     private function addSearchResultExtractorSection(ArrayNodeDefinition $nodeDefinition): void
     {
-        /** @noinspection NullPointerExceptionInspection */
+        /* @noinspection NullPointerExceptionInspection */
         $nodeDefinition
             ->children()
                 ->booleanNode('use_loading_search_result_extractor')
@@ -73,7 +74,7 @@ class Configuration implements ConfigurationInterface
 
     private function addAsynchronousIndexingSection(ArrayNodeDefinition $nodeDefinition): void
     {
-        /** @noinspection NullPointerExceptionInspection */
+        /* @noinspection NullPointerExceptionInspection */
         $nodeDefinition
             ->children()
                 ->booleanNode('use_asynchronous_indexing')
@@ -85,7 +86,7 @@ class Configuration implements ConfigurationInterface
 
     private function addFulltextBoostSection(ArrayNodeDefinition $nodeDefinition): void
     {
-        /** @noinspection NullPointerExceptionInspection */
+        /* @noinspection NullPointerExceptionInspection */
         $nodeDefinition
             ->children()
                 ->arrayNode('fulltext')
@@ -248,5 +249,29 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    private function addFileTextExtractionSection(ArrayNodeDefinition $nodeDefinition): void
+    {
+        $nodeDefinition
+            ->children()
+                ->arrayNode('file_text_extraction')
+                ->addDefaultsIfNotSet()
+                ->info('File text extraction configuration for ezbinaryfile')
+                ->children()
+                    ->scalarNode('java_executable_path')
+                        ->info('Path to Java executable')
+                        ->defaultValue('/usr/bin/java')
+                    ->end()
+                    ->arrayNode('allowed_mime_types')
+                        ->info('List of allowed MIME types for text extraction')
+                        ->scalarPrototype()->end()
+                        ->defaultValue([
+                            'application/pdf',
+                        ])
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
     }
 }

--- a/bundle/DependencyInjection/NetgenIbexaSearchExtraExtension.php
+++ b/bundle/DependencyInjection/NetgenIbexaSearchExtraExtension.php
@@ -94,6 +94,7 @@ class NetgenIbexaSearchExtraExtension extends Extension implements PrependExtens
         $this->processFullTextBoostConfiguration($configuration, $container);
         $this->processUsePageIndexingConfiguration($configuration, $container);
         $this->processPageIndexingConfiguration($configuration, $container);
+        $this->processFileTextExtractionConfiguration($configuration, $container);
     }
 
     private function processSearchResultExtractorConfiguration(array $configuration, ContainerBuilder $container): void
@@ -155,6 +156,19 @@ class NetgenIbexaSearchExtraExtension extends Extension implements PrependExtens
         $container->setParameter(
             'netgen_ibexa_search_extra.page_indexing.enabled',
             $configuration['page_indexing']['enabled'] ?? false,
+        );
+    }
+
+    private function processFileTextExtractionConfiguration(array $configuration, ContainerBuilder $container): void
+    {
+        $container->setParameter(
+            'netgen_ibexa_search_extra.file_text_extraction.java_executable_path',
+            $configuration['file_text_extraction']['java_executable_path'],
+        );
+
+        $container->setParameter(
+            'netgen_ibexa_search_extra.file_text_extraction.allowed_mime_types',
+            $configuration['file_text_extraction']['allowed_mime_types'],
         );
     }
 }

--- a/lib/Core/FieldType/BinaryFile/SearchField.php
+++ b/lib/Core/FieldType/BinaryFile/SearchField.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\IbexaSearchExtra\Core\FieldType\BinaryFile;
+
+use Ibexa\Contracts\Core\FieldType\Indexable;
+use Ibexa\Contracts\Core\Persistence\Content\Field;
+use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
+use Ibexa\Contracts\Core\Search;
+use Netgen\IbexaSearchExtra\Core\Search\Common\PageIndexing\TextExtractor\FileTextExtractor;
+
+use function trim;
+
+/**
+ * Indexable definition for BinaryFile field type.
+ */
+final class SearchField implements Indexable
+{
+    /** @var array<int, array<int, string>> */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly Indexable $innerField,
+        private readonly FileTextExtractor $fileTextExtractor,
+    ) {}
+
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition): array
+    {
+        $searchFields = $this->innerField->getIndexData($field, $fieldDefinition);
+
+        $text = $this->extractText($field);
+
+        if ($text !== '') {
+            $searchFields[] = new Search\Field(
+                'file_text',
+                $text,
+                new Search\FieldType\FullTextField(),
+            );
+        }
+
+        return $searchFields;
+    }
+
+    public function getIndexDefinition(): array
+    {
+        $innerDef = $this->innerField->getIndexDefinition();
+        $innerDef['file_text'] = new Search\FieldType\FullTextField();
+
+        return $innerDef;
+    }
+
+    public function getDefaultMatchField(): ?string
+    {
+        return $this->innerField->getDefaultMatchField();
+    }
+
+    public function getDefaultSortField(): ?string
+    {
+        return $this->innerField->getDefaultSortField();
+    }
+
+    private function extractText(Field $field): string
+    {
+        if (!isset($this->cache[$field->id][$field->versionNo])) {
+            $this->cache = [];
+            $this->cache[$field->id][$field->versionNo] = trim($this->fileTextExtractor->extractFromPersistenceField($field));
+        }
+
+        return $this->cache[$field->id][$field->versionNo];
+    }
+}

--- a/lib/Core/Search/Common/PageIndexing/TextExtractor/FileTextExtractor.php
+++ b/lib/Core/Search/Common/PageIndexing/TextExtractor/FileTextExtractor.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\IbexaSearchExtra\Core\Search\Common\PageIndexing\TextExtractor;
+
+use Ibexa\Contracts\Core\Persistence\Content\Field;
+use Ibexa\Core\FieldType\BinaryBase\Value;
+use Ibexa\Core\IO\IOServiceInterface;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+use function in_array;
+use function sprintf;
+
+/**
+ * Extract text from Ibexa file based field types.
+ */
+final class FileTextExtractor
+{
+    public function __construct(
+        private readonly IOServiceInterface $binaryFileIoService,
+        private readonly string $projectDir,
+        private readonly string $apacheTikaDir,
+        private readonly string $javaDir,
+        private readonly array $allowedMimeTypes,
+    ) {}
+
+    public function extractFromPersistenceField(Field $field): string
+    {
+        return isset($field->value->externalData['id'])
+            ? $this->extractByFileId($field->value->externalData['id'])
+            : '';
+    }
+
+    public function extractFromValue(Value $value): string
+    {
+        return $value->id === null ? '' : $this->extractByFileId($value->id);
+    }
+
+    public function extractByFileId(string $fileId): string
+    {
+        $mimeType = $this->binaryFileIoService->getMimeType($fileId);
+
+        if (!in_array($mimeType, $this->allowedMimeTypes, true)) {
+            return '';
+        }
+
+        $file = $this->binaryFileIoService->loadBinaryFile($fileId);
+
+        $process = new Process(
+            [
+                $this->javaDir,
+                '-jar',
+                $this->apacheTikaDir,
+                '--text',
+                sprintf('public%s', $file->uri),
+            ],
+            $this->projectDir,
+        );
+        $process->run();
+        $exitCode = $process->getExitCode();
+
+        if ($exitCode !== 0) {
+            throw new RuntimeException(
+                sprintf(
+                    'Could not extract text from file with ID "%s": %s',
+                    $fileId,
+                    $process->getExitCodeText(),
+                ),
+            );
+        }
+
+        return $process->getOutput();
+    }
+}

--- a/lib/Resources/config/search/common.yaml
+++ b/lib/Resources/config/search/common.yaml
@@ -11,3 +11,11 @@ services:
 
     Netgen\IbexaSearchExtra\Core\Search\Common\Query\ConfiguredFulltextCriterionFactory:
         alias: netgen.ibexa_search_extra.fulltext.configured_factory
+
+    Netgen\IbexaSearchExtra\Core\Search\Common\PageIndexing\TextExtractor\FileTextExtractor:
+        arguments:
+            - '@ibexa.field_type.ezbinaryfile.io_service'
+            - '%kernel.project_dir%'
+            - 'vendor/netgen/ibexa-search-extra/bin/tika-app-3.2.0.jar'
+            - '%netgen_ibexa_search_extra.file_text_extraction.java_executable_path%'
+            - '%netgen_ibexa_search_extra.file_text_extraction.allowed_mime_types%'

--- a/lib/Resources/config/search/common.yaml
+++ b/lib/Resources/config/search/common.yaml
@@ -12,6 +12,12 @@ services:
     Netgen\IbexaSearchExtra\Core\Search\Common\Query\ConfiguredFulltextCriterionFactory:
         alias: netgen.ibexa_search_extra.fulltext.configured_factory
 
+    Netgen\IbexaSearchExtra\Core\FieldType\BinaryFile\SearchField:
+        decorates: Ibexa\Core\FieldType\BinaryFile\SearchField
+        arguments:
+            $innerField: '@.inner'
+            $fileTextExtractor: '@Netgen\IbexaSearchExtra\Core\Search\Common\PageIndexing\TextExtractor\FileTextExtractor'
+
     Netgen\IbexaSearchExtra\Core\Search\Common\PageIndexing\TextExtractor\FileTextExtractor:
         arguments:
             - '@ibexa.field_type.ezbinaryfile.io_service'


### PR DESCRIPTION
- `FileTextExtractor` - a service that contains logic for extracting text from some file (pdf for now) using Apache Tika jar file
- `BinaryFile/SearchField` - overrides the usual `Ibexa\Core\FieldType\BinaryFile\SearchField` file by adding **file_text** info to also be indexable 
- `lib/Resources/config/search/common.yaml` - this is where I've put the configuration for `FileTextExtractor` and `SearchField` services. If this config needs to be somewhere else, let me know
- add config param `file_text_extraction` with two params under it: `java_executable_path` and `allowed_mime_types`. The former param specifies the path to the java executable (if not specified the path will be '_/usr/bin/java_'). The latter param specified the allowed MIME types from which text can be extracted. 